### PR TITLE
Spelling fixes for Shogun

### DIFF
--- a/anjiro.zil
+++ b/anjiro.zil
@@ -1836,7 +1836,7 @@ curiosity: what will the barbarian do next?" CR>)
 "You grab for the crucifix, but Sebastio snatches it away, holding
 it up as if to ward you off.  \"Demon!  Heretic!\" he screams.  \"You'd
 love to defile this holy cross to prove to these pagans you're also a
-satan worshipper and an enemy of the church!  You'll die first!\"" CR>
+Satan worshipper and an enemy of the church!  You'll die first!\"" CR>
 		       <JAPANESE-INTERESTED?>)>)>>
 
 <ROUTINE JAPANESE-INTERESTED? ()

--- a/anjiro.zil
+++ b/anjiro.zil
@@ -2947,7 +2947,7 @@ agree, say it directly to him.\"" CR>)
 			(<NOT <B-LYING?>>
 			 <COND (<EQUAL? ,DELAY-CNT 1>
 				<TELL CR
-"Omi watches you with great curiousity." CR>
+"Omi watches you with great curiosity." CR>
 				<RTRUE>)
 			       (<EQUAL? <CROOCQ-IN-CAULDRON> T>
 				<COND (<EQUAL? ,DELAY-CNT 2 3>

--- a/anjiro.zil
+++ b/anjiro.zil
@@ -592,7 +592,7 @@ find you've returned to the house you left." CR>)
 		       <FCLEAR ,OMI ,RMUNGBIT> ;"he won't kill you"
 		       <TELL
 "You walk up the dirt path that leads to the fields, watched by curious
-eyes every second.  In the terraced fields are farmers up to the their knees
+eyes every second.  In the terraced fields are farmers up to their knees
 in water, planting and weeding.  How can anything grow in such wetness,
 you wonder, and how can the fields have been built on such steep
 hillsides?  Confused, you walk back to the house you left." CR>)>)

--- a/attack.zil
+++ b/attack.zil
@@ -487,7 +487,7 @@ back is straight." CR>)>>
 	       (<VERB? EXAMINE>
 		<COND (<FSET? ,PRSO ,DEAD>
 		       <TELL
-"Achiko's lifeless body is spawled on the floor." CR>)
+"Achiko's lifeless body is sprawled on the floor." CR>)
 		      (ELSE
 		       <TELL
 "She appears to be holding up well." CR>)>)>>

--- a/audience.zil
+++ b/audience.zil
@@ -483,7 +483,7 @@ the old man's servility." CR>)
 			 <COND (<OR <G? ,DELAY-CNT 3>
 				    <NOT <PASSIVE-VERB?>>>
 				<TELL CR
-"Toranaga looks up slowly, gestures imperceptably at Hiro-matsu, and
+"Toranaga looks up slowly, gestures imperceptibly at Hiro-matsu, and
 goes back to his falconry.  Hiro-matsu rises, bows to Toranaga, and
 slays you with a single stroke.">
 				<JIGS-UP>

--- a/audience.zil
+++ b/audience.zil
@@ -1947,7 +1947,7 @@ little else.  The interiors are almost entirely mysteries.\"" CR>)
 	 <COND (<PRSI? ,ME>
 		<TELL
 "You relate the story of your life. Toranaga questions
-you closely about many points, particulary those relating to war and
+you closely about many points, particularly those relating to war and
 politics." CR>)
 	       (<PRSI? ,DOMINGO ,PRISON>
 		<HOW-I-LEARNED>)

--- a/cast.zil
+++ b/cast.zil
@@ -1428,7 +1428,7 @@ Toranaga.  "G"He is dressed in the Gray uniform." CR>)
 		<TELL
 "Ishido Kazunari is Commander of the
 garrison of Osaka Castle, Commander of the Heir's Bodyguard, Chief General
-of the Armies of the West, Conquerer of Korea, member of the Council of
+of the Armies of the West, Conqueror of Korea, member of the Council of
 Regents, and Inspector General of the Armies of the late Taiko." CR>)
 	       (<P? TELL-ABOUT ISHIDO (TORANAGA KIRITSUBO TORANAGA-IN-DRAG)>
 		<COND (,SEEN-TORANAGA?

--- a/erasmus.zil
+++ b/erasmus.zil
@@ -2798,7 +2798,7 @@ rocks.">)>>
 "He stirs weakly, but otherwise doesn't respond." CR>)>)
 	       (<VERB? PISS>
 		<TELL
-"You have come to hate him, but to humilate him in his helpless,
+"You have come to hate him, but to humiliate him in his helpless,
 weakened condition would be too much." CR>)
 	       (<VERB? MOVE>
 		<TELL "He's too weak to be moved." CR>)

--- a/erasmus.zil
+++ b/erasmus.zil
@@ -2539,7 +2539,7 @@ sea." CR>)>)
 "You let go of the wheel." CR>)
 		      (ELSE
 		       <TELL
-"You arent' holding it." CR>)>)
+"You aren't holding it." CR>)>)
 	       (<P? PUT LASHING WHEEL>
 		<PERFORM ,V?TIE ,WHEEL>
 		<RTRUE>)

--- a/mariko.zil
+++ b/mariko.zil
@@ -375,11 +375,11 @@ steps forward, standing directly in her way.  \"May I see your
 papers?\" he inquires.|
 |
 Mariko says formally, \"We require none.  I am Toda Mariko-noh-Buntaro
-and I have been ordered by my leige Lord, Lord Toranaga, to escort his
+and I have been ordered by my liege Lord, Lord Toranaga, to escort his
 ladies to meet him.  Kindly let us pass.\"|
 |
 \"My name is Yamazaki Danzenji, Captain of the Fourth Legion, and my line
-is as ancient as your own, my Lady.  Please excuse me, but my leige Lord,
+is as ancient as your own, my Lady.  Please excuse me, but my liege Lord,
 Lord Ishido, says no one may
 leave Osaka Castle without papers.\"|
 |
@@ -431,8 +431,8 @@ Mariko turns to Ishido and bows.  \"My orders are clear.  If I am not
 permitted to obey, I will not be able to live with that shame.\"" CR>)
 		 (<TELL CR
 "\"These men have prevented me from
-doing my duty, from obeying my leige Lord.  I cannot live with this
-shame, Sire.  Unless we are allowed to obey our leige Lord, as is our
+doing my duty, from obeying my liege Lord.  I cannot live with this
+shame, Sire.  Unless we are allowed to obey our liege Lord, as is our
 right, I will commit seppuku at sunset!\"|
 |
 She bows and walks toward the gateway.  All in the avenue and all on the

--- a/mariko.zil
+++ b/mariko.zil
@@ -206,7 +206,7 @@ bad.  Lady Ochiba seems surprised." CR>)
 				<SETG OCHIBA-QUESTION 0>
 				<TELL CR
 "\"Bah!  It is clear he is a barbarian without honor!\"  Ishido turns
-away with a snort of dirision." CR>
+away with a snort of derision." CR>
 				<RTRUE>)
 			       (ELSE
 				<TELL CR

--- a/mariko.zil
+++ b/mariko.zil
@@ -405,7 +405,7 @@ vanguard.  From up ahead twenty more Grays move silently out from the
 hundreds that are waiting.|
 |
 \"Wait,\" Mariko orders.  She steps out of her palanquin and picks up
-a sword, unsheaths it, and walks forward alone.  She approaches the
+a sword, unsheathes it, and walks forward alone.  She approaches the
 officer.  \"You know who I am.  Please get out of my way.\"|
 |
 \"I am Kojima Harutomo, Captain of the Sixth Legion.  Please excuse me,


### PR DESCRIPTION
These are the spelling fixes for Shogun from The ZIL Files. The usual caveats apply: I'm not a native English speaker, so please check that the fixes are correct.
